### PR TITLE
Fix missing imports and wrong import module name

### DIFF
--- a/autostarter/__init__.py
+++ b/autostarter/__init__.py
@@ -1,1 +1,2 @@
 from .autostarter import add, remove
+from .systems import windows, linux, darwin

--- a/autostarter/autostarter.py
+++ b/autostarter/autostarter.py
@@ -8,7 +8,7 @@ def _get_os_module():
     """
     Returns the OS-specific module for the current operating system.
     """
-    return importlib.import_module('startup.systems.' + platform.system().lower())
+    return importlib.import_module('autostarter.systems.' + platform.system().lower())
 
 def add(script_location, **kwargs):
     """

--- a/autostarter/systems/__init__.py
+++ b/autostarter/systems/__init__.py
@@ -1,0 +1,1 @@
+from . import darwin, linux, windows

--- a/autostarter/systems/darwin.py
+++ b/autostarter/systems/darwin.py
@@ -58,7 +58,14 @@ def remove(identifier: str, system_wide: bool = False) -> bool:
         f'{_startup_folder(system_wide)}/{identifier}.sh'
     ]
 
-    return all(os.remove(file) for file in to_delete)
+    try:
+        for file in to_delete:
+            os.remove(file)
+    except Exception as e:
+        print("autostarter - exception occured while removing launch agent: " + str(e))
+        return False
+    
+    return True
 
 def _startup_folder(system_wide: bool) -> str:
     """


### PR DESCRIPTION
Scripts inside system were not included in the package since no init file was present.
Also the module name to import those was wrong ("startup", maybe this script old name ?)

I fixed them and tried installing this module with pip and works correctly.

Great work, thanks 